### PR TITLE
Fix build due to new checks in PostgreSQL 16

### DIFF
--- a/vops.c
+++ b/vops.c
@@ -1924,7 +1924,7 @@ Datum vops_text_output(PG_FUNCTION_ARGS)
 PG_FUNCTION_INFO_V1(vops_text_typmod_in);
 Datum vops_text_typmod_in(PG_FUNCTION_ARGS)
 {
-    ArrayType* arr = (ArrayType*)DatumGetPointer(PG_DETOAST_DATUM(PG_GETARG_DATUM(0)));
+    ArrayType* arr = (ArrayType*) PG_DETOAST_DATUM(PG_GETARG_DATUM(0));
     int n;
     int32* typemods = ArrayGetIntegerTypmods(arr, &n);
     int len;
@@ -4418,7 +4418,7 @@ vops_substitute_tables_with_projections(char const* queryString, Query *query)
 			datum = SPI_getbinval(tuple, tupDesc, 3, &isnull);
 			if (!isnull)
 			{
-				vectorColumns = (ArrayType*)DatumGetPointer(PG_DETOAST_DATUM(datum));
+				vectorColumns = (ArrayType*) PG_DETOAST_DATUM(datum);
 
 				/* Construct set of used vector columns */
 				deconstruct_array(vectorColumns, INT4OID, 4, true, 'i', &vectorAttnos, NULL, &nVectorColumns);
@@ -4431,7 +4431,7 @@ vops_substitute_tables_with_projections(char const* queryString, Query *query)
 			datum = SPI_getbinval(tuple, tupDesc, 4, &isnull);
 			if (!isnull)
 			{
-				scalarColumns = isnull ? NULL : (ArrayType*)DatumGetPointer(PG_DETOAST_DATUM(datum));
+				scalarColumns = isnull ? NULL : (ArrayType*) PG_DETOAST_DATUM(datum);
 
 				/* Construct set of used scalar columns */
 				deconstruct_array(scalarColumns, INT4OID, 4, true, 'i', &scalarAttnos, NULL, &nScalarColumns);

--- a/vops.h
+++ b/vops.h
@@ -3,8 +3,8 @@
 
 #define VOPS_SIZEOF_TEXT(width) (LONGALIGN(VARHDRSZ) + sizeof(vops_tile_hdr) + (width)*TILE_SIZE)
 #define VOPS_ELEM_SIZE(var)     ((VARSIZE(var) - LONGALIGN(VARHDRSZ) - sizeof(vops_tile_hdr)) / TILE_SIZE)
-#define VOPS_TEXT_TILE(val)     ((vops_tile_hdr*)((char*)DatumGetTextP(val) + LONGALIGN(VARHDRSZ)))
-#define VOPS_GET_TILE(val,tid)  (((tid) == VOPS_TEXT) ? VOPS_TEXT_TILE(val) : (vops_tile_hdr*)DatumGetPointer(val))
+#define VOPS_TEXT_TILE(val)     ((vops_tile_hdr*)((char*) pg_detoast_datum(val) + LONGALIGN(VARHDRSZ)))
+#define VOPS_GET_TILE(val,tid)  (((tid) == VOPS_TEXT) ? VOPS_TEXT_TILE((struct varlena *) DatumGetPointer(val)) : (vops_tile_hdr*)DatumGetPointer(val))
 
 typedef enum
 {


### PR DESCRIPTION
Due to the commit c8b2ef05f481ef06326d7b9f3eb14b303f215c7e in PostgreSQL 16 the macro PG_DETOAST_DATUM returns a pointer to a varlena structure and the input to the function DatumGetPointer must be of type Datum. So
- Use a simple cast instead of the function DatumGetPointer.
- In the macro VOPS_TEXT_TILE use the function pg_detoast_datum directly instead of the macro DatumGetTextP. As a result, call the function DatumGetPointer in the macro VOPS_GET_TILE because here the val type is usually Datum.