### PR TITLE
Fix compiler warnings due to new checks in PostgreSQL 16

### DIFF
--- a/vops.c
+++ b/vops.c
@@ -2970,7 +2970,7 @@ Datum vops_import(PG_FUNCTION_ARGS)
 					  text* t = DatumGetTextP(val);
 					  int elem_size = types[i].len;
 					  int len = VARSIZE(t) - VARHDRSZ;
-					  char* dst = (char*)(tile + 1);
+					  dst = (char*)(tile + 1);
 					  if (len < elem_size) {
 						  memcpy(dst + j*elem_size, VARDATA(t), len);
 						  memset(dst + j*elem_size + len, 0, elem_size - len);

--- a/vops_fdw.c
+++ b/vops_fdw.c
@@ -1215,10 +1215,11 @@ foreign_grouping_ok(PlannerInfo *root, RelOptInfo *grouped_rel)
 				 */
 				foreach(l, aggvars)
 				{
-					Expr	   *expr = (Expr *) lfirst(l);
+					Expr	   *current_expr = (Expr *) lfirst(l);
 
-					if (IsA(expr, Aggref))
-						tlist = add_to_flat_tlist(tlist, list_make1(expr));
+					if (IsA(current_expr, Aggref))
+						tlist = add_to_flat_tlist(tlist,
+												  list_make1(current_expr));
 				}
 			}
 		}
@@ -1240,8 +1241,6 @@ foreign_grouping_ok(PlannerInfo *root, RelOptInfo *grouped_rel)
 	 */
 	if (root->hasHavingQual && query->havingQual)
 	{
-		ListCell   *lc;
-
 		foreach(lc, (List *) query->havingQual)
 		{
 			Expr	   *expr = (Expr *) lfirst(lc);
@@ -1259,9 +1258,8 @@ foreign_grouping_ok(PlannerInfo *root, RelOptInfo *grouped_rel)
 	 */
 	if (fpinfo->local_conds)
 	{
-		ListCell   *lc;
-		List	   *aggvars = pull_var_clause((Node *) fpinfo->local_conds,
-											  PVC_INCLUDE_AGGREGATES);
+		aggvars = pull_var_clause((Node *) fpinfo->local_conds,
+								  PVC_INCLUDE_AGGREGATES);
 
 		foreach(lc, aggvars)
 		{


### PR DESCRIPTION
See the commit 0fe954c28584169938e5c0738cfaa9930ce77577 (Add -Wshadow=compatible-local to the standard compilation flags) in PostgreSQL 16.

```
vops_fdw.c: In function ‘foreign_grouping_ok’:
vops_fdw.c:1218:53: warning: declaration of ‘expr’ shadows a previous local [-Wshadow=compatible-local]
 1218 |                                         Expr       *expr = (Expr *) lfirst(l);
      |                                                     ^~~~
vops_fdw.c:1161:29: note: shadowed declaration is here
 1161 |                 Expr       *expr = (Expr *) lfirst(lc);
      |                             ^~~~
vops_fdw.c:1243:29: warning: declaration of ‘lc’ shadows a previous local [-Wshadow=compatible-local]
 1243 |                 ListCell   *lc;
      |                             ^~
vops_fdw.c:1118:21: note: shadowed declaration is here
 1118 |         ListCell   *lc;
      |                     ^~
vops_fdw.c:1262:29: warning: declaration of ‘lc’ shadows a previous local [-Wshadow=compatible-local]
 1262 |                 ListCell   *lc;
      |                             ^~
vops_fdw.c:1118:21: note: shadowed declaration is here
 1118 |         ListCell   *lc;
      |                     ^~
vops_fdw.c:1263:29: warning: declaration of ‘aggvars’ shadows a previous local [-Wshadow=compatible-local]
 1263 |                 List       *aggvars = pull_var_clause((Node *) fpinfo->local_conds,
      |                             ^~~~~~~
vops_fdw.c:1117:21: note: shadowed declaration is here
 1117 |         List       *aggvars;
      |                     ^~~~~~~
vops.c: In function ‘vops_import’:
vops.c:2973:49: warning: declaration of ‘dst’ shadows a previous local [-Wshadow=compatible-local]
 2973 |                                           char* dst = (char*)(tile + 1);
      |                                                 ^~~
vops.c:2828:31: note: shadowed declaration is here
 2828 |                         char* dst;
      |                               ^~~
```