### PR TITLE
Remove postgres_fdw_validator declaration

### DIFF
--- a/vops_fdw.c
+++ b/vops_fdw.c
@@ -201,14 +201,6 @@ vops_fdw_handler(PG_FUNCTION_ARGS)
 }
 
 
-/*
- * Validate the generic options given to a FOREIGN DATA WRAPPER, SERVER,
- * USER MAPPING or FOREIGN TABLE that uses postgres_fdw.
- *
- * Raise an ERROR if the option or its value is considered invalid.
- */
-PG_FUNCTION_INFO_V1(postgres_fdw_validator);
-
 Datum
 vops_fdw_validator(PG_FUNCTION_ARGS)
 {


### PR DESCRIPTION
It is not actually used here, but before that we found the duplicate symbol pg_finfo_postgres_fdw_validator in the shared libraries postgres_fdw.so and vops.so.