### PR TITLE
PGPRO-8122: Use updated ExecInsertIndexTuples() for 16+

### DIFF
--- a/vops.c
+++ b/vops.c
@@ -1173,7 +1173,12 @@ UserTableUpdateOpenIndexes()
 #if PG_VERSION_NUM>=140000
 											   false,
 #endif
+
+#if PG_VERSION_NUM>=160000
+											   false, NULL, NIL, false);
+#else
 											   false, NULL, NIL);
+#endif
 		if (recheckIndexes != NIL)
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),


### PR DESCRIPTION
Caused by:
  - 19d8e2308bc51ec4ab993ce90077342c915dd116 (PostgreSQL) Ignore BRIN indexes when checking for HOT updates Tag: vops