### PR TITLE
[PGPRO-14916] Fix compilation after PR #31

### DIFF
--- a/vops_fdw.c
+++ b/vops_fdw.c
@@ -440,9 +440,12 @@ postgresGetForeignPaths(PlannerInfo *root,
 								   fpinfo->rows,
 								   fpinfo->startup_cost,
 								   fpinfo->total_cost,
-								   NIL, /* no pathkeys */
+								   NIL,			/* no pathkeys */
 								   NULL,		/* no outer rel either */
 								   NULL,		/* no extra plan */
+#if PG_VERSION_NUM>=170000
+								   NIL,			/* no fdw_restrictinfo list */
+#endif
 								   NIL);		/* no fdw_private list */
 	add_path(baserel, (Path *) path);
 }
@@ -1411,8 +1414,11 @@ add_foreign_grouping_paths(PlannerInfo *root, RelOptInfo *input_rel,
 										  startup_cost,
 										  total_cost,
 										  NIL,	/* no pathkeys */
-										  NULL,
-										  NIL); /* no fdw_private */
+										  NULL,	/* no extra plan */
+#if PG_VERSION_NUM>=170000
+										  NIL,	/* no fdw_restrictinfo list */
+#endif
+										  NIL); /* no fdw_private list */
 #else
 	grouppath = create_foreignscan_path(root,
 										grouped_rel,
@@ -1422,8 +1428,11 @@ add_foreign_grouping_paths(PlannerInfo *root, RelOptInfo *input_rel,
 										total_cost,
 										NIL,	/* no pathkeys */
 										grouped_rel->lateral_relids,
-										NULL,
-										NIL);	/* no fdw_private */
+										NULL,	/* no extra plan */
+#if PG_VERSION_NUM>=170000
+										NIL,	/* no fdw_restrictinfo list */
+#endif
+										NIL);	/* no fdw_private list */
 #endif
 
 	/* Add generated path into grouped_rel by add_path(). */

--- a/vops_fdw.c
+++ b/vops_fdw.c
@@ -438,7 +438,6 @@ postgresGetForeignPaths(PlannerInfo *root,
 								   baserel,
 								   NULL,		/* default pathtarget */
 								   fpinfo->rows,
-								   0,
 								   fpinfo->startup_cost,
 								   fpinfo->total_cost,
 								   NIL, /* no pathkeys */
@@ -1409,7 +1408,6 @@ add_foreign_grouping_paths(PlannerInfo *root, RelOptInfo *input_rel,
 										  grouped_rel,
 										  grouped_rel->reltarget,
 										  rows,
-										  0,
 										  startup_cost,
 										  total_cost,
 										  NIL,	/* no pathkeys */


### PR DESCRIPTION
PR #31 was intended to make vops compatible with PostgreSQL 18. Unfortunately, after merging it, vops compiles neither with PostgreSQL 18 nor with PostgreSQL 17 and earlier.

Revert erroneous commit, and make vops compatible with PostgreSQL 17, which we already have done, but forgot to merge in master by mistake.

Compatibility with PostgreSQL 18 is NOT provided.